### PR TITLE
telink: b9x: Enable CONFIG_IEEE802154_2015 for b9x

### DIFF
--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -271,6 +271,9 @@ config OPENTHREAD_DEFAULT_TX_POWER
     default 3 if PM
     default 9
 
+config IEEE802154_2015
+    default y
+
 endif # NET_L2_OPENTHREAD
 
 config NET_TX_STACK_SIZE


### PR DESCRIPTION
- Enable aes/ske hardware encryption to improve performance.
