### PR TITLE
W91 add pwm pool

### DIFF
--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -110,7 +110,7 @@ jobs:
                 platform: telink
             - name: Update Zephyr to specific revision (for developers purpose)
               shell: bash
-              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 36ba616c818ee4603f6195e977052180bb56b7ae"
+              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 68deadeb5c20b82d68700e720d4580e8003bf1d8"
             - name: CI Examples Telink
               shell: bash
               run: |

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -57,7 +57,7 @@ jobs:
                 gh-context: ${{ toJson(github) }}
 
             - name: Update Zephyr to specific revision (for developers purpose)
-              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 36ba616c818ee4603f6195e977052180bb56b7ae"
+              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 68deadeb5c20b82d68700e720d4580e8003bf1d8"
 
             - name: Build example Telink (B92 retention) Air Quality Sensor App
               run: |

--- a/config/telink/chip-module/Kconfig
+++ b/config/telink/chip-module/Kconfig
@@ -180,7 +180,7 @@ config CHIP_LOG_SIZE_OPTIMIZATION
 
 config CHIP_BUTTON_MANAGER_IRQ_MODE
 	bool "Use GPIO in an IRQ mode instead of polling the GPIO"
-	default PM
+	default PM || BOARD_TLSR9118BDK40D
 	help
 	  Use GPIO in an IRQ mode to avoid button polling loop and extend the battery lifetime by waking up by GPIO event. 
 	  GPIO events are working only with GPIO IRQ. This option changes button matrix configuration. 

--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -344,7 +344,7 @@ endif # CHIP_WIFI
 
 config CHIP_ENABLE_PAIRING_AUTOSTART
     bool "Open commissioning window on boot"
-    default n
+    default y
     help
         Opens the commissioning window automatically at application boot time if
         the node is not yet commissioned.

--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -344,7 +344,7 @@ endif # CHIP_WIFI
 
 config CHIP_ENABLE_PAIRING_AUTOSTART
     bool "Open commissioning window on boot"
-    default y 
+    default n
     help
         Opens the commissioning window automatically at application boot time if
         the node is not yet commissioned.

--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -373,7 +373,7 @@ void AppTaskCommon::InitPwms()
 
 void AppTaskCommon::LinkPwms(PwmManager & pwmManager)
 {
-#if CONFIG_WS2812_STRIP
+#if CONFIG_WS2812_STRIP || CONFIG_BOARD_TLSR9118BDK40D // TLSR9118BDK40D EVK buttons located on 4th PWM channel (see tlsr9118bdk40d.overlay)
     pwmManager.linkPwm(PwmManager::EAppPwm_Red, 0);
     pwmManager.linkPwm(PwmManager::EAppPwm_Green, 1);
     pwmManager.linkPwm(PwmManager::EAppPwm_Blue, 2);

--- a/src/platform/telink/tlsr9118bdk40d.overlay
+++ b/src/platform/telink/tlsr9118bdk40d.overlay
@@ -4,7 +4,7 @@
 		compatible = "gpio-keys";
 
 		inp {
-			gpios = <&gpio0 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			gpios = <&gpio0 21 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
 					<&gpio0 15 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
 	};
@@ -27,7 +27,24 @@
 		compatible = "gpio-leds";
 
 		out {
-			gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
 		};
 	};
+	pwm_pool {
+		compatible = "pwm-leds";
+		out {
+			pwms = <&pwm0 4 PWM_MSEC(1) PWM_POLARITY_NORMAL>,
+				   <&pwm0 1 PWM_MSEC(1) PWM_POLARITY_NORMAL>,			
+				   <&pwm0 2 PWM_MSEC(1) PWM_POLARITY_NORMAL>,
+				   <&pwm0 3 PWM_MSEC(1) PWM_POLARITY_NORMAL>;
+		};
+	};
+};
+
+&pwm0 {
+	/* On board RGB LEDs */
+	pinctrl-ch4 = <&pwm_ch4_p20_default>;
+	pinctrl-ch1 = <&pwm_ch1_p16_default>;
+	pinctrl-ch2 = <&pwm_ch2_p17_default>;
+	pinctrl-ch3 = <&pwm_ch3_p18_default>;
 };

--- a/src/platform/telink/tlsr9118bdk40d.overlay
+++ b/src/platform/telink/tlsr9118bdk40d.overlay
@@ -4,7 +4,7 @@
 		compatible = "gpio-keys";
 
 		inp {
-			gpios = <&gpio0 21 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			gpios = <&gpio0 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
 					<&gpio0 15 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
 	};
@@ -34,7 +34,6 @@
 		compatible = "pwm-leds";
 		out {
 			pwms = <&pwm0 4 PWM_MSEC(1) PWM_POLARITY_NORMAL>,
-				   <&pwm0 1 PWM_MSEC(1) PWM_POLARITY_NORMAL>,			
 				   <&pwm0 2 PWM_MSEC(1) PWM_POLARITY_NORMAL>,
 				   <&pwm0 3 PWM_MSEC(1) PWM_POLARITY_NORMAL>;
 		};
@@ -44,7 +43,6 @@
 &pwm0 {
 	/* On board RGB LEDs */
 	pinctrl-ch4 = <&pwm_ch4_p20_default>;
-	pinctrl-ch1 = <&pwm_ch1_p16_default>;
 	pinctrl-ch2 = <&pwm_ch2_p17_default>;
 	pinctrl-ch3 = <&pwm_ch3_p18_default>;
 };


### PR DESCRIPTION
Add pwm pool for w91 platform.
W91 EVK board has limitation (we can use only 3 pwm cchannels if we want to use two buttons)

