### PR TITLE
[Telink] memory layout and default config changes

### DIFF
--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -122,7 +122,7 @@ jobs:
                 platform: telink
             - name: Update Zephyr to specific revision (for developers purpose)
               shell: bash
-              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 80ba99a8fd90427d10513255c25104d8ea94b3b1"
+              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 7c5d3acfbeb25d115cfb6542616f0e7906b4c70a"
             - name: CI Examples Telink
               shell: bash
               run: |

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -71,7 +71,7 @@ jobs:
                 gh-context: ${{ toJson(github) }}
 
             - name: Update Zephyr to specific revision (for developers purpose)
-              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 80ba99a8fd90427d10513255c25104d8ea94b3b1"
+              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 7c5d3acfbeb25d115cfb6542616f0e7906b4c70a"
 
             - name: Build example Telink (B92 retention) Air Quality Sensor App
               # Run test for master and s07641069 PRs
@@ -178,14 +178,14 @@ jobs:
             - name: clean out build output (keep tools)
               run: rm -rf ./out/telink*
 
-            - name: Build example Telink (TL3218) Lighting App with OTA (LZMA), Shell, Factory Data
+            - name: Build example Telink (TL3218) Lighting App with OTA (LZMA), Factory Data
               # Run test for master and all PRs
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --target 'telink-tl3218-light-ota-compress-lzma-shell-factory-data' build"
+                    "./scripts/build/build_examples.py --target 'telink-tl3218-light-ota-compress-lzma-factory-data' build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    telink tl3218 light-app-ota-compress-lzma-shell-factory-data \
-                    out/telink-tl3218-light-ota-compress-lzma-shell-factory-data/zephyr/zephyr.elf \
+                    telink tl3218 light-app-ota-compress-lzma-factory-data \
+                    out/telink-tl3218-light-ota-compress-lzma-factory-data/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
 
             - name: clean out build output (keep tools)

--- a/config/telink/app/bootloader.conf
+++ b/config/telink/app/bootloader.conf
@@ -29,12 +29,15 @@ CONFIG_BOOT_SWAP_USING_SCRATCH=n
 # With disabled option the only image magic is validated
 CONFIG_BOOT_VALIDATE_SLOT0=y
 
-# Sets log level for modules which don't specify it explicitly.
-# When set to 0 it means log will not be activated for those modules.
-# Levels are:
-#  - 0 OFF, do not write by default
-#  - 1 ERROR, default to only write LOG_LEVEL_ERR
-#  - 2 WARNING, default to write LOG_LEVEL_WRN
-#  - 3 INFO, default to write LOG_LEVEL_INFO
-#  - 4 DEBUG, default to write LOG_LEVEL_DBG
-CONFIG_LOG_DEFAULT_LEVEL=3
+# MCUBOOT log levels are:
+#  - OFF, LOG_LEVEL_ERR_OFF
+#  - ERROR,  LOG_LEVEL_ERR
+#  - WARNING,  LOG_LEVEL_WRN
+#  - INFO,  LOG_LEVEL_INF
+#  - DEBUG, LOG_LEVEL_DBG
+CONFIG_MCUBOOT_LOG_LEVEL_ERR=y
+
+# TODO: revert before merge (made to first run Jenkins)
+CONFIG_EXCEPTION_DEBUG=n
+CONFIG_PICOLIBC=y
+CONFIG_GPIO=n

--- a/config/telink/app/bootloader_compress_lzma.conf
+++ b/config/telink/app/bootloader_compress_lzma.conf
@@ -22,15 +22,13 @@ CONFIG_BOOT_UPGRADE_ONLY=y
 # With disabled option the only image magic is validated
 CONFIG_BOOT_VALIDATE_SLOT0=y
 
-# Sets log level for modules which don't specify it explicitly.
-# When set to 0 it means log will not be activated for those modules.
-# Levels are:
-#  - 0 OFF, do not write by default
-#  - 1 ERROR, default to only write LOG_LEVEL_ERR
-#  - 2 WARNING, default to write LOG_LEVEL_WRN
-#  - 3 INFO, default to write LOG_LEVEL_INFO
-#  - 4 DEBUG, default to write LOG_LEVEL_DBG
-CONFIG_LOG_DEFAULT_LEVEL=3
+# MCUBOOT log levels are:
+#  - OFF, LOG_LEVEL_ERR_OFF
+#  - ERROR,  LOG_LEVEL_ERR
+#  - WARNING,  LOG_LEVEL_WRN
+#  - INFO,  LOG_LEVEL_INF
+#  - DEBUG, LOG_LEVEL_DBG
+CONFIG_MCUBOOT_LOG_LEVEL_INF=y
 
 # LZMA used sys_heap based allocators
 CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=78000

--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -83,7 +83,8 @@ config HEAP_MEM_POOL_SIZE
     default 1280
 
 config COMMON_LIBC_MALLOC_ARENA_SIZE
-    default 20716 if SOC_RISCV_TELINK_TL321X || SOC_SERIES_RISCV_TELINK_B9X_RETENTION
+    default 20716 if  SOC_SERIES_RISCV_TELINK_B9X_RETENTION
+    default 16384 if  SOC_RISCV_TELINK_TL321X
     default 12288
 
 config NET_IPV6_MLD
@@ -104,11 +105,13 @@ config NET_PKT_TX_COUNT
     default 8
 
 config NET_BUF_RX_COUNT
-    default 4 if PM || SOC_RISCV_TELINK_TL321X
+    default 4 if PM
+    default 16 if SOC_RISCV_TELINK_TL321X
     default 32
 
 config NET_BUF_TX_COUNT
-    default 4 if PM || SOC_RISCV_TELINK_TL321X
+    default 4 if PM
+    default 16 if SOC_RISCV_TELINK_TL321X
     default 32
 
 config GPIO
@@ -148,8 +151,6 @@ config BT_BUF_ACL_TX_SIZE
     default 107 if SOC_RISCV_TELINK_TL321X
     default 251
 
-if SOC_RISCV_TELINK_TL321X
-
 config BT_BUF_EVT_RX_COUNT
     default 4
 
@@ -159,8 +160,6 @@ config BT_BUF_ACL_RX_COUNT
 config BT_GATT_CACHING
     bool
     default n
-
-endif # SOC_RISCV_TELINK_TL321X
 
 config BT_RX_STACK_SIZE
     default 1352 if BT_B9X
@@ -427,6 +426,10 @@ config MBEDTLS_USER_CONFIG_ENABLE
 
 config MBEDTLS_USER_CONFIG_FILE
     default "telink-mbedtls-config.h"
+
+config MBEDTLS_ZEPHYR_ENTROPY
+    bool
+    default y
 
 config MBEDTLS_CIPHER_AES_ENABLED
 	default y

--- a/src/platform/telink/tlsr9258a_2m_flash.overlay
+++ b/src/platform/telink/tlsr9258a_2m_flash.overlay
@@ -9,23 +9,23 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0xf000>;
+			reg = <0x00000000 0xb000>;
 		};
-		slot0_partition: partition@f000 {
+		slot0_partition: partition@b000 {
 			label = "image-0";
-			reg = <0xf000 0xf1000>;
+			reg = <0xb000 0xf3000>;
 		};
-		factory_partition: partition@100000 {
+		factory_partition: partition@fe000 {
 			label = "factory-data";
-			reg = <0x100000 0x1000>;
+			reg = <0xfe000 0x1000>;
 		};
-		storage_partition: partition@101000 {
+		storage_partition: partition@ff000 {
 			label = "storage";
-			reg = <0x101000 0xc000>;
+			reg = <0xff000 0xc000>;
 		};
-		slot1_partition: partition@10d000 {
+		slot1_partition: partition@10b000 {
 			label = "image-1";
-			reg = <0x10d000 0xf1000>;
+			reg = <0x10b000 0xf3000>;
 		};
 		vendor_partition: partition@1fe000 {
 			label = "vendor-data";

--- a/src/platform/telink/tlsr9518adk80d_2m_flash.overlay
+++ b/src/platform/telink/tlsr9518adk80d_2m_flash.overlay
@@ -9,23 +9,23 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0xf000>;
+			reg = <0x00000000 0xd000>;
 		};
-		slot0_partition: partition@f000 {
+		slot0_partition: partition@d000 {
 			label = "image-0";
-			reg = <0xf000 0xf1000>;
+			reg = <0xd000 0xf2000>;
 		};
-		factory_partition: partition@100000 {
+		factory_partition: partition@ff000 {
 			label = "factory-data";
-			reg = <0x100000 0x1000>;
+			reg = <0xff000 0x1000>;
 		};
-		storage_partition: partition@101000 {
+		storage_partition: partition@100000 {
 			label = "storage";
-			reg = <0x101000 0xc000>;
+			reg = <0x100000 0xc000>;
 		};
-		slot1_partition: partition@10d000 {
+		slot1_partition: partition@10c000 {
 			label = "image-1";
-			reg = <0x10d000 0xf1000>;
+			reg = <0x10c000 0xf2000>;
 		};
 		vendor_partition: partition@1fe000 {
 			label = "vendor-data";

--- a/src/platform/telink/tlsr9528a_2m_flash.overlay
+++ b/src/platform/telink/tlsr9528a_2m_flash.overlay
@@ -9,31 +9,23 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0xf000>;
+			reg = <0x00000000 0xd000>;
 		};
-		slot0_partition: partition@f000 {
+		slot0_partition: partition@d000 {
 			label = "image-0";
-			reg = <0xf000 0xee000>;
+			reg = <0xd000 0xf2000>;
 		};
-		factory_partition: partition@fd000 {
+		factory_partition: partition@ff000 {
 			label = "factory-data";
-			reg = <0xfd000 0x1000>;
+			reg = <0xff000 0x1000>;
 		};
-		dac_keypair_partition: partition@fe000 {
- 			label = "dac-keypair";
-			reg = <0xfe000 0x1000>; //store dac and key pair.
- 		};
-		descriptor_partition: partition@ff000 {
-			label = "sboot-descriptor";
-			reg = <0xff000 0x2000>;
-		};
-		storage_partition: partition@101000 {
+		storage_partition: partition@100000 {
 			label = "storage";
-			reg = <0x101000 0xf000>;
+			reg = <0x100000 0xc000>;
 		};
-		slot1_partition: partition@110000 {
+		slot1_partition: partition@10c000 {
 			label = "image-1";
-			reg = <0x110000 0xee000>;
+			reg = <0x10c000 0xf2000>;
 		};
 		vendor_partition: partition@1fe000 {
 			label = "vendor-data";


### PR DESCRIPTION
Reduced MCUBoot partitions by 0x1000 and removed two other partitions getting 0x3000 to distribute 0x4000 between slot0 and slot1 for B92.
Reduced MCUBoot partition for B91 and B95, increased app slots from there.
Kconfig.defaults changes to reduce ROM usage on B92 lighting OTA.

TODO:
- fix W91 commissioning on max target config (ota, factory, shell, thread analyzer)
