### PR TITLE
riscv: telink: add driven features for tlsr9528 and tl3218

### DIFF
--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -288,6 +288,18 @@ config STARTUP_OPTIMIZATION
     bool "Optimize startup speed"
     default n
 
+config BUTTON_FACTORY_RESET
+    bool "Do factory reset base on button"
+    default n
+
+config STORAGE_OTA_STATUS
+    bool "Store ota status base on analog register"
+    default n
+
+config EXPOSE_CHIPID_VIA_BLE
+    bool "Get CHIP ID via ble"
+    default n
+
 # Set multiplicator of Name Value Storage (NVS) as 1 to reach NVS sector size 4KB
 # nvs_sector_size = flash_page_size * mult = 4KB * 1 = 4KB
 config SETTINGS_NVS_SECTOR_SIZE_MULT

--- a/examples/lighting-app/telink/src/AppTask.cpp
+++ b/examples/lighting-app/telink/src/AppTask.cpp
@@ -23,6 +23,8 @@
 #include "LEDManager.h"
 #include "PWMManager.h"
 #include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/kernel.h>
 
@@ -59,8 +61,15 @@ void AppTask::PowerOnFactoryReset(void)
 #endif /* CONFIG_CHIP_ENABLE_POWER_ON_FACTORY_RESET */
 
 #if CONFIG_CUSTOMER_MODE
-void i2c_demo_proc()
+/**
+ * @brief Use I2C to transfer data.
+ *
+ * @see CONFIG_I2C=y must be set in prj.conf
+ * when you need to use I2C module.
+ */
+void i2c_demo_proc(void)
 {
+#if CONFIG_I2C
     const uint8_t tx_buf[23] = { 0xc0, 0x63, 0x3f, 0x63, 0x63, 0x63, 0x22, 0x22, 0x00, 0x00, 0x00, 0x00,
                                  0x3f, 0x3f, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0x2b, 0x06, 0xbe };
     /* add the i2c module here */
@@ -82,8 +91,96 @@ void i2c_demo_proc()
     }
     i2c_write(i2c.bus, tx_buf + 1, sizeof(tx_buf) - 1, tx_buf[0]);
     printk("i2c demo stop ,finish transfer\n");
+#endif // CONFIG_I2C
 }
 
+/**
+ * @brief Use ADC to sampling.
+ *
+ * @see CONFIG_ADC=y must be set in prj.conf
+ * when you need to use ADC module.
+ */
+
+/* Data of ADC io-channels specified in devicetree. */
+#define DT_SPEC_AND_COMMA(node_id, prop, idx) ADC_DT_SPEC_GET_BY_IDX(node_id, idx),
+
+void adc_demo_proc(void)
+{
+#if CONFIG_ADC
+    static const struct adc_dt_spec adc_channels[] = { DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channels, DT_SPEC_AND_COMMA) };
+
+    /* Define ADC data structure. */
+    uint16_t buf;
+    struct adc_sequence sequence = {
+        .buffer = &buf,
+        /* buffer size in bytes, not number of samples */
+        .buffer_size = sizeof(buf),
+    };
+
+    int err = 0;
+
+    /* Configure channels individually prior to sampling. */
+    for (size_t i = 0U; i < ARRAY_SIZE(adc_channels); i++)
+    {
+        if (!device_is_ready(adc_channels[i].dev))
+        {
+            printf("ADC controller device %s not ready\n", adc_channels[i].dev->name);
+            return;
+        }
+        err = adc_channel_setup_dt(&adc_channels[i]);
+        if (err < 0)
+        {
+            printf("Could not setup channel #%d (%d)\n", i, err);
+            return;
+        }
+    }
+
+    /* ADC sampling. */
+    for (size_t i = 0U; i < ARRAY_SIZE(adc_channels); i++)
+    {
+        printf("- %s, channel %d: ", adc_channels[i].dev->name, adc_channels[i].channel_id);
+        (void) adc_sequence_init_dt(&adc_channels[i], &sequence);
+        err = adc_read(adc_channels[i].dev, &sequence);
+        if (err < 0)
+        {
+            printf("Could not read (%d)\n", err);
+            continue;
+        }
+
+        int32_t val_mv = 0;
+
+        /*
+         * If using differential mode, the 16 bit value
+         * in the ADC sample buffer should be a signed 2's
+         * complement value.
+         */
+        if (adc_channels[i].channel_cfg.differential)
+        {
+            val_mv = (int32_t) ((int16_t) buf);
+        }
+        else
+        {
+            val_mv = (int32_t) buf;
+        }
+        printf("%" PRId32, val_mv);
+
+        /* conversion to mV may not be supported, skip if not */
+        err = adc_raw_to_millivolts_dt(&adc_channels[i], &val_mv);
+        if (err < 0)
+        {
+            printf(" (value in mV not available)\n");
+        }
+        else
+        {
+            printf(" = %" PRId32 " mV\n", val_mv);
+        }
+    }
+#endif // CONFIG_ADC
+}
+
+/**
+ * @brief Set cluster info.
+ */
 #define MATTER_COLORMODE_ENABLE 0
 
 void AppTask::Set_cluster_info(void)
@@ -119,6 +216,9 @@ void AppTask::Set_cluster_info(void)
     status = Clusters::LevelControl::Attributes::OnOffTransitionTime::Set(1, p_para->onoff_transition);
 }
 
+/**
+ * @brief Get cluster info.
+ */
 void AppTask::Init_cluster_info(void)
 {
     light_para_t * p_para = &light_para;
@@ -160,8 +260,7 @@ void AppTask::Init_cluster_info(void)
     // Read OnOffTransitionTime value
     status = Clusters::LevelControl::Attributes::OnOffTransitionTime::Get(1, &(p_para->onoff_transition));
 }
-
-#endif
+#endif // CONFIG_CUSTOMER_MODE
 
 CHIP_ERROR AppTask::Init(void)
 {

--- a/examples/platform/telink/common/include/AppTaskCommon.h
+++ b/examples/platform/telink/common/include/AppTaskCommon.h
@@ -194,11 +194,16 @@ protected:
     static void TestOTAHandler(AppEvent * aEvent);
 #endif
 
+#if CONFIG_BUTTON_FACTORY_RESET
+    static void ButtonFactoryReset(void);
+#endif // CONFIG_BUTTON_FACTORY_RESET
+
     static void ExampleActionButtonEventHandler(void);
 
     void SetExampleButtonCallbacks(EventHandler aAction_CB);
     EventHandler ExampleActionEventHandler;
 
+    static void OtaEventsHandler(const chip::DeviceLayer::ChipDeviceEvent * event);
     static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
 
     static void UpdateStatusLED(void);

--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -18,6 +18,7 @@
 
 #include "AppTaskCommon.h"
 #include "AppTask.h"
+#include <analog.h>
 
 #include "BLEManagerImpl.h"
 #include "ButtonManager.h"
@@ -475,6 +476,58 @@ void AppTaskCommon::PrintFirmwareInfo(void)
     LOG_DBG("\t HAL commit: %.8s%s %s", TELINK_HAL_COMMIT_HASH, TELINK_HAL_LOCAL_STATUS, TELINK_HAL_COMMIT_DATE);
 #endif
 }
+
+/**
+ * @brief Use analog register to store OTA status.
+ *
+ * @see There are many OTA callback events in
+ * AppTaskCommon::OtaEventsHandler, please embed it as needed.
+ */
+#if CONFIG_STORAGE_OTA_STATUS
+#if CONFIG_SOC_RISCV_TELINK_B92
+#define ANALOG_REG_ADR 0x3b
+#define ANALOG_OTA_FLAG_VAL 0x55
+
+void OtaSetAnaFlag(void)
+{
+    analog_write(ANALOG_REG_ADR, ANALOG_OTA_FLAG_VAL);
+}
+
+bool OtaGetAnaFlag(void)
+{
+    if (analog_read(ANALOG_REG_ADR) == ANALOG_OTA_FLAG_VAL)
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+#endif // CONFIG_SOC_RISCV_TELINK_B92
+#endif // CONFIG_STORAGE_OTA_STATUS
+
+/**
+ * @brief Control factory reset base on button.
+ *
+ * @see It must set CONFIG_CHIP_BUTTON_MANAGER_IRQ_MODE=y
+ * in prj.conf if you need to use independent button to control
+ * factory reset. Otherwise, the matrix key will be used by default.
+ */
+#if CONFIG_BUTTON_FACTORY_RESET
+void AppTaskCommon::ButtonFactoryReset(void)
+{
+    ButtonManager & buttonManager = ButtonManager::getInstance();
+    buttonManager.addCallback(AppTaskCommon::FactoryResetButtonEventHandler, 0, true);
+
+#if CONFIG_CHIP_BUTTON_MANAGER_IRQ_MODE
+    buttonManager.linkBackend(ButtonPool::getInstance());
+#else
+    buttonManager.linkBackend(ButtonMatrix::getInstance());
+#endif // CONFIG_CHIP_BUTTON_MANAGER_IRQ_MODE
+}
+#endif // CONFIG_BUTTON_FACTORY_RESET
+
 CHIP_ERROR AppTaskCommon::InitCommonParts(void)
 {
     CHIP_ERROR err;
@@ -947,6 +1000,36 @@ void AppTaskCommon::SetExampleButtonCallbacks(EventHandler aAction_CB)
     ExampleActionEventHandler = aAction_CB;
 }
 
+void AppTaskCommon::OtaEventsHandler(const ChipDeviceEvent * event)
+{
+    switch (event->OtaStateChanged.newState)
+    {
+    case DeviceLayer::kOtaDownloadInProgress:
+        ChipLogProgress(DeviceLayer, "OTA image download in progress\n");
+        break;
+    case DeviceLayer::kOtaDownloadComplete:
+        ChipLogProgress(DeviceLayer, "OTA image download complete\n");
+        break;
+    case DeviceLayer::kOtaDownloadFailed:
+        ChipLogProgress(DeviceLayer, "OTA image download failed\n");
+        break;
+    case DeviceLayer::kOtaDownloadAborted:
+        ChipLogProgress(DeviceLayer, "OTA image download aborted\n");
+        break;
+    case DeviceLayer::kOtaApplyInProgress:
+        ChipLogProgress(DeviceLayer, "OTA image apply in progress\n");
+        break;
+    case DeviceLayer::kOtaApplyComplete:
+        ChipLogProgress(DeviceLayer, "OTA image apply complete\n");
+        break;
+    case DeviceLayer::kOtaApplyFailed:
+        ChipLogProgress(DeviceLayer, "OTA image apply failed\n");
+        break;
+    default:
+        break;
+    }
+}
+
 void AppTaskCommon::ChipEventHandler(const ChipDeviceEvent * event, intptr_t /* arg */)
 {
     switch (event->Type)
@@ -1065,6 +1148,9 @@ void AppTaskCommon::ChipEventHandler(const ChipDeviceEvent * event, intptr_t /* 
 #if CONFIG_CHIP_ENABLE_APPLICATION_STATUS_LED
         UpdateStatusLED();
 #endif
+        break;
+    case DeviceEventType::kOtaStateChanged:
+        AppTaskCommon::OtaEventsHandler(event);
         break;
     default:
         break;

--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -76,6 +76,10 @@ const bt_uuid_128 UUID128_CHIPoBLEChar_TX =
 const bt_uuid_128 UUID128_CHIPoBLEChar_C3 =
     BT_UUID_INIT_128(0x04, 0x8F, 0x21, 0x83, 0x8A, 0x74, 0x7D, 0xB8, 0xF2, 0x45, 0x72, 0x87, 0x38, 0x02, 0x63, 0x64);
 #endif
+#if CHIP_DEVICE_EXPOSE_CHIPID_VIA_BLE
+const bt_uuid_128 UUID128_CHIPoBLEChar_ChipID =
+    BT_UUID_INIT_128(0x04, 0x8F, 0x21, 0x83, 0x8A, 0x74, 0x7D, 0xB8, 0xF2, 0x45, 0x72, 0x87, 0x38, 0x02, 0xA1, 0x01);
+#endif // CHIP_DEVICE_EXPOSE_CHIPID_VIA_BLE
 
 bt_uuid_16 UUID16_CHIPoBLEService = BT_UUID_INIT_16(0xFFF6);
 
@@ -100,6 +104,12 @@ bt_gatt_attr sChipoBleAttributes[] = {
                                BT_GATT_PERM_READ,
                                BLEManagerImpl::HandleC3Read, nullptr, nullptr),
 #endif
+#if CHIP_DEVICE_EXPOSE_CHIPID_VIA_BLE
+        BT_GATT_CHARACTERISTIC(&UUID128_CHIPoBLEChar_ChipID.uuid,
+                               BT_GATT_CHRC_READ,
+                               BT_GATT_PERM_READ,
+                               BLEManagerImpl::HandleChipIDRead, nullptr, nullptr),
+#endif // CHIP_DEVICE_EXPOSE_CHIPID_VIA_BLE
 };
 
 bt_gatt_service sChipoBleService = BT_GATT_SERVICE(sChipoBleAttributes);
@@ -899,6 +909,19 @@ ssize_t BLEManagerImpl::HandleC3Read(struct bt_conn * conId, const struct bt_gat
                              sInstance.c3CharDataBufferHandle->DataLength());
 }
 #endif
+
+#if CHIP_DEVICE_EXPOSE_CHIPID_VIA_BLE
+#include <zephyr/drivers/hwinfo.h>
+ssize_t BLEManagerImpl::HandleChipIDRead(struct bt_conn * conId, const struct bt_gatt_attr * attr, void * buf, uint16_t len,
+                                         uint16_t offset)
+{
+    ChipLogDetail(DeviceLayer, "Read request received for CHIPoBLE Chip ID (ConnId 0x%02x)", bt_conn_index(conId));
+
+    uint8_t chip_id_value[16] = { 0 };
+    efuse_get_chip_id(chip_id_value);
+    return bt_gatt_attr_read(conId, attr, buf, len, offset, chip_id_value, sizeof(chip_id_value));
+}
+#endif // CHIP_DEVICE_EXPOSE_CHIPID_VIA_BLE
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 CHIP_ERROR BLEManagerImpl::HandleOperationalNetworkEnabled(const ChipDeviceEvent * event)

--- a/src/platform/telink/BLEManagerImpl.h
+++ b/src/platform/telink/BLEManagerImpl.h
@@ -167,6 +167,11 @@ public:
     static ssize_t HandleC3Read(struct bt_conn * conn, const struct bt_gatt_attr * attr, void * buf, uint16_t len, uint16_t offset);
 #endif
 
+#if CHIP_DEVICE_EXPOSE_CHIPID_VIA_BLE
+    static ssize_t HandleChipIDRead(struct bt_conn * conn, const struct bt_gatt_attr * attr, void * buf, uint16_t len,
+                                    uint16_t offset);
+#endif // CHIP_DEVICE_EXPOSE_CHIPID_VIA_BLE
+
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     // Switch context from BLE to Thread
     void SwitchToIeee802154(void);

--- a/src/platform/telink/CHIPDevicePlatformConfig.h
+++ b/src/platform/telink/CHIPDevicePlatformConfig.h
@@ -120,6 +120,12 @@
 #define CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE 0
 #endif
 
+#ifdef CONFIG_EXPOSE_CHIPID_VIA_BLE
+#define CHIP_DEVICE_EXPOSE_CHIPID_VIA_BLE CONFIG_EXPOSE_CHIPID_VIA_BLE
+#else
+#define CHIP_DEVICE_EXPOSE_CHIPID_VIA_BLE 0
+#endif
+
 // ========== Platform-specific Configuration =========
 
 // These are configuration options that are unique to Zephyr platforms.

--- a/src/platform/telink/tl3218x.overlay
+++ b/src/platform/telink/tl3218x.overlay
@@ -40,6 +40,10 @@
 					<&pwm0 2 PWM_MSEC(1) PWM_POLARITY_NORMAL>;
 		};
 	};
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts for adc demo. */
+		io-channels = <&adc 0>;
+	};
 };
 
 &pwm0 {
@@ -58,5 +62,21 @@
 	};
 	pwm_ch2_pb2_default: pwm_ch2_pb2_default {
 		pinmux = <TLX_PINMUX_SET(TLX_PORT_B, TLX_PIN_2, TL321X_FUNC_PWM2)>;
+	};
+};
+
+&adc {
+	/* the channel setting for adc demo */
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <DT_ADC_VBAT>;
 	};
 };

--- a/src/platform/telink/tlsr9528a.overlay
+++ b/src/platform/telink/tlsr9528a.overlay
@@ -40,6 +40,11 @@
 					<&pwm0 2 PWM_MSEC(1) PWM_POLARITY_NORMAL>;
 		};
 	};
+
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts for adc demo. */
+		io-channels = <&adc 0>;
+	};
 };
 
 &pwm0 {
@@ -58,5 +63,21 @@
 	};
 	pwm_ch2_pd0_default: pwm_ch2_pd0_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_0, B92_FUNC_PWM2)>;
+	};
+};
+
+&adc {
+	/* the channel setting for adc demo */
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <DT_ADC_VBAT>;
 	};
 };


### PR DESCRIPTION
 - add factory reset based on button control .
 - add adc for sampling the chip voltage .
 - add ota events process handler .
 - add analog register to store ota events status .
 - add gatt service to expose chip_id when advertisement .

> !!!!!!!!!! Please delete the instructions below and replace with PR description
>
> If you have an issue number, please use a syntax of
> `Fixes #12345` and a brief change description
>
> If you do not have an issue number, please have a good description of
> the problem and the fix. Help the reviewer understand what to expect.
>
> Make sure you delete these instructions (to prove you have read them).
>
> !!!!!!!!!! Instructions end

