### PR TITLE
[Telink] Fix binary operations for OTA LZMA dual-mode

### DIFF
--- a/config/telink/chip-module/CMakeLists.txt
+++ b/config/telink/chip-module/CMakeLists.txt
@@ -163,27 +163,12 @@ endif()
 # Define 'process_binaries' target for collecting final binary to flash
 # ==============================================================================
 
-if(CONFIG_SOC_RISCV_TELINK_TL321X)
-set(SOC "TL321X")
-set(ZB_FW_OFFSET "912")
-elseif(CONFIG_SOC_RISCV_TELINK_B92)
-set(SOC "B92")
-set(ZB_FW_OFFSET "1280")
-endif()
-set(ZB_FILE_PATH "${ZEPHYR_BASE}/ZB_FW/${SOC}/concurrent_sampleLight.bin")
-set(BLOCK_SIZE "1024")
-
 add_custom_target(
     process_binaries ALL
     COMMAND ${Python3_EXECUTABLE} ${CHIP_ROOT}/scripts/tools/telink/process_binaries.py
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
 )
-
-if(EXISTS ${ZB_FILE_PATH} AND CONFIG_BOOTLOADER_MCUBOOT AND (CONFIG_SOC_SERIES_RISCV_TELINK_B9X OR CONFIG_SOC_SERIES_RISCV_TELINK_TLX))
-    add_dependencies(process_binaries west_sign)
-else()
-    add_dependencies(process_binaries ${ZEPHYR_FINAL_EXECUTABLE})
-endif()
+add_dependencies(process_binaries ${ZEPHYR_FINAL_EXECUTABLE})
 
 # ==============================================================================
 # Define 'build_mcuboot' target for building the MCUBoot bootloader
@@ -197,30 +182,6 @@ if (CONFIG_BOOTLOADER_MCUBOOT AND (CONFIG_SOC_SERIES_RISCV_TELINK_B9X OR CONFIG_
         COMMAND
         cp ${PROJECT_BINARY_DIR}/../modules/chip-module/build_mcuboot/zephyr/zephyr.bin ${PROJECT_BINARY_DIR}/mcuboot.bin
     )
-
-    if(EXISTS ${ZB_FILE_PATH})
-        add_custom_target(merge_zigbee ALL
-            COMMAND
-            dd if=/dev/zero bs=${BLOCK_SIZE} count=${ZB_FW_OFFSET} | tr '\\000' '\\377' > ${PROJECT_BINARY_DIR}/dm_merged.bin
-            COMMAND
-            dd if=${PROJECT_BINARY_DIR}/zephyr.bin of=${PROJECT_BINARY_DIR}/dm_merged.bin conv=notrunc
-            COMMAND
-            dd if=${ZB_FILE_PATH} of=${PROJECT_BINARY_DIR}/dm_merged.bin bs=${BLOCK_SIZE} seek=${ZB_FW_OFFSET} conv=notrunc
-            COMMAND
-            cp ${PROJECT_BINARY_DIR}/dm_merged.bin ${PROJECT_BINARY_DIR}/zephyr.bin
-        )
-        add_custom_target(west_sign ALL
-            COMMAND
-            west sign -t imgtool -p ${ZEPHYR_BASE}/../bootloader/mcuboot/scripts/imgtool.py -d ${PROJECT_BINARY_DIR}/.. -- --key ${ZEPHYR_BASE}/../bootloader/mcuboot/root-rsa-2048.pem
-        )
-    else()
-        message(WARNING "File ${ZB_FILE_PATH} does not exist. merge_zigbee target will not be created.")
-    endif()
-
-    if(EXISTS ${ZB_FILE_PATH})
-        add_dependencies(merge_zigbee ${ZEPHYR_FINAL_EXECUTABLE})
-        add_dependencies(west_sign merge_zigbee)
-    endif()
 endif()
 
 # ==============================================================================

--- a/config/telink/chip-module/Kconfig
+++ b/config/telink/chip-module/Kconfig
@@ -71,10 +71,15 @@ config CHIP_OTA_IMAGE_BUILD
 	bool
 	default y if CHIP_OTA_REQUESTOR
 
+config DEFAULT_SIGNED_OTA_IMAGE_FILE_NAME
+	string "Default Zephyr signed image file name"
+	default "zephyr.signed.bin"
+	depends on CHIP_OTA_REQUESTOR
+
 config SIGNED_OTA_IMAGE_FILE_NAME
 	string "Zephyr signed image file name"
 	default "zephyr.signed.lzma.signed.bin" if COMPRESS_LZMA
-	default "zephyr.signed.bin"
+	default DEFAULT_SIGNED_OTA_IMAGE_FILE_NAME
 	depends on CHIP_OTA_REQUESTOR
 	help
 	  Provides the file name of the generated Zephyr signed image.
@@ -259,3 +264,8 @@ config SECURE_PROGRAMMING
 	bool "Enable reading DAC and keys from the DAC partition"
 	depends on CHIP_FACTORY_DATA
 	default n
+
+config TELINK_ZB_PARTITION_ADDR
+	hex "Zigbee partition address"
+	default $(dt_node_reg_addr_hex,$(dt_nodelabel_path,zb_partition),0)
+	depends on SOC_RISCV_TELINK_TL321X || SOC_RISCV_TELINK_B92

--- a/examples/platform/telink/common/include/AppTaskCommon.h
+++ b/examples/platform/telink/common/include/AppTaskCommon.h
@@ -43,14 +43,8 @@
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/sys/reboot.h>
 
-#if CONFIG_SOC_RISCV_TELINK_B92
-#define ZB_NVS_PARTITION zigbee_partition
+#define ZB_NVS_PARTITION zigbee_nvs_partition
 #define ZB_NVS_SEC_SIZE FIXED_PARTITION_SIZE(ZB_NVS_PARTITION)
-#elif CONFIG_SOC_RISCV_TELINK_TL321X
-#define ZB_NVS_PARTITION slot1_partition
-/* zb para locate in the slot1 , and it will cost 104k size in slot1 */
-#define ZB_NVS_SEC_SIZE (104 * 1024)
-#endif
 
 #define ZB_NVS_PARTITION_DEVICE FIXED_PARTITION_DEVICE(ZB_NVS_PARTITION)
 #define ZB_NVS_START_ADR FIXED_PARTITION_OFFSET(ZB_NVS_PARTITION)

--- a/scripts/tools/telink/process_binaries.py
+++ b/scripts/tools/telink/process_binaries.py
@@ -136,6 +136,8 @@ if build_conf.getboolean('CONFIG_SOC_RISCV_TELINK_TL321X'):
     SoC = 'TL321X'
 elif build_conf.getboolean('CONFIG_SOC_RISCV_TELINK_B92'):
     SoC = 'B92'
+else:
+    SoC = ''
 ZB_FILE_PATH = os.path.join(ZEPHYR_BASE, 'ZB_FW', SoC, 'concurrent_sampleLight.bin')
 
 if os.path.exists(ZB_FILE_PATH):

--- a/scripts/tools/telink/process_binaries.py
+++ b/scripts/tools/telink/process_binaries.py
@@ -123,13 +123,50 @@ if build_conf.getboolean('CONFIG_SOC_SERIES_RISCV_TELINK_W91'):
             '--slot-size', str(build_conf['CONFIG_FLASH_LOAD_SIZE']),
             '--key', os.path.join(ZEPHYR_BASE, '../', build_conf['CONFIG_MCUBOOT_SIGNATURE_KEY_FILE']),
             'merged.bin',
-            build_conf['CONFIG_SIGNED_OTA_IMAGE_FILE_NAME']
+            build_conf['CONFIG_DEFAULT_SIGNED_OTA_IMAGE_FILE_NAME']
         ]
         try:
             subprocess.run(sign_command, check=True)
             os.remove('merged.bin')  # Clean up merged.bin after signing
         except subprocess.CalledProcessError as e:
             raise RuntimeError(f"Error signing the image: {e}")
+
+# Telink dual-mode Zigbee binary operations
+if build_conf.getboolean('CONFIG_SOC_RISCV_TELINK_TL321X'):
+    SoC = 'TL321X'
+elif build_conf.getboolean('CONFIG_SOC_RISCV_TELINK_B92'):
+    SoC = 'B92'
+ZB_FILE_PATH = os.path.join(ZEPHYR_BASE, 'ZB_FW', SoC, 'concurrent_sampleLight.bin')
+
+if os.path.exists(ZB_FILE_PATH):
+    zb_partition_offset = build_conf['CONFIG_TELINK_ZB_PARTITION_ADDR']
+    if build_conf.getboolean('CONFIG_BOOTLOADER_MCUBOOT'):
+        zb_partition_offset -= build_conf['CONFIG_FLASH_LOAD_OFFSET']
+
+    # Merge Zigbee binary
+    merge_binaries('zephyr.bin', ZB_FILE_PATH, 'merged.bin', zb_partition_offset)
+
+    # Sign the image if MCUBoot is used
+    if build_conf.getboolean('CONFIG_BOOTLOADER_MCUBOOT'):
+        sign_command = [
+            'python3',
+            os.path.join(ZEPHYR_BASE, '../bootloader/mcuboot/scripts/imgtool.py'),
+            'sign',
+            '--version', '0.0.0+0',
+            '--align', '1',
+            '--header-size', str(build_conf['CONFIG_ROM_START_OFFSET']),
+            '--slot-size', str(build_conf['CONFIG_FLASH_LOAD_SIZE']),
+            '--key', os.path.join(ZEPHYR_BASE, '../', build_conf['CONFIG_MCUBOOT_SIGNATURE_KEY_FILE']),
+            'merged.bin',
+            build_conf['CONFIG_DEFAULT_SIGNED_OTA_IMAGE_FILE_NAME']
+        ]
+        try:
+            subprocess.run(sign_command, check=True)
+            os.remove('merged.bin')  # Clean up merged.bin after signing
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"Error signing the image: {e}")
+else:
+    print(f"File {ZB_FILE_PATH} does not exist. Merge Zigbee binary will not be performed.")
 
 # Merge MCUBoot binary if configured
 if build_conf.getboolean('CONFIG_BOOTLOADER_MCUBOOT'):

--- a/src/platform/telink/tl3218x_2m_flash.overlay
+++ b/src/platform/telink/tl3218x_2m_flash.overlay
@@ -33,6 +33,10 @@
 			// Zigbee NVS data will also reside here.
 			reg = <0x134000 0xb2000>;
 		};
+		zigbee_nvs_partition: partition@134000_1 {
+			label = "zigbee-nvs";
+			reg = <0x134000 0x1a000>; // zigbee nvs part , total is 104k.
+		};
 		storage_partition: partition@1e6000 {
 			label = "storage";
 			// NVS storage for Matter.

--- a/src/platform/telink/tl3218x_2m_flash.overlay
+++ b/src/platform/telink/tl3218x_2m_flash.overlay
@@ -20,6 +20,12 @@
 			// totaling 0x122000 in size.
 			reg = <0x12000 0x122000>;
 		};
+		zb_partition: partition@f6000 {
+			label = "image-zb";
+			// Zigbee partition
+			// End address should be same as of slot0 partition
+			reg = <0xf6000 0x3e000>;
+		};
 		slot1_partition: partition@134000 {
 			label = "image-1";
 			// Uses LZMA compression to reduce binary size.

--- a/src/platform/telink/tlsr9528a_4m_flash.overlay
+++ b/src/platform/telink/tlsr9528a_4m_flash.overlay
@@ -33,8 +33,8 @@
 			label = "storage";
 			reg = <0x380000 0xb000>; // matter nvs part 
 		};
-		zigbee_partition: partition@38b000 {
-			label = "zigbee";
+		zigbee_nvs_partition: partition@38b000 {
+			label = "zigbee-nvs";
 			reg = <0x38b000 0x1a000>; // zigbee nvs part , total is 104k.
 		};
 		user_token_partition: partition@3a5000 {

--- a/src/platform/telink/tlsr9528a_4m_flash.overlay
+++ b/src/platform/telink/tlsr9528a_4m_flash.overlay
@@ -19,7 +19,7 @@
 			label = "image-zb";
 			// Zigbee partition
 			// End address should be same as of slot0 partition
-			reg = <0x154000 0x65000>;
+			reg = <0x154000 0x60000>;
 		};
 		slot1_partition: partition@1b9000 {
 			label = "image-1";

--- a/src/platform/telink/tlsr9528a_4m_flash.overlay
+++ b/src/platform/telink/tlsr9528a_4m_flash.overlay
@@ -6,12 +6,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
-		/delete-node/ partition@0;
-		/delete-node/ partition@20000;
-		/delete-node/ partition@88000;
-		/delete-node/ partition@f0000;
-		/delete-node/ partition@f4000;
-		/delete-node/ partition@fe000;
+
 		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x00000000 0x14000>;
@@ -19,6 +14,12 @@
 		slot0_partition: partition@14000 {
 			label = "image-0";
 			reg = <0x14000 0x1a5000>;// 0x14000 is matter , 0x154000 is zigbee , 0x1b4000~0x1b9000 reserved for trailor and move sector, should be 20k
+		};
+		zb_partition: partition@154000 {
+			label = "image-zb";
+			// Zigbee partition
+			// End address should be same as of slot0 partition
+			reg = <0x154000 0x65000>;
 		};
 		slot1_partition: partition@1b9000 {
 			label = "image-1";


### PR DESCRIPTION
**Change overview**

- Move merge of Zigbee binary from CMake into process_binaries.py
- Add partition for Zigbee binary (TELINK_ZB_PARTITION_ADDR) instead of hardcoded values