### PR TITLE
[Telink] Add Thread Optimization Configs

### DIFF
--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -111,7 +111,7 @@ jobs:
                 platform: telink
             - name: Update Zephyr to specific revision (for developers purpose)
               shell: bash
-              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py b8320f9853c629f627389ed87eb16149d1e05a5c"
+              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py e8f404c8dd3ddca76e862fbfd395f2b38fabc8b5"
             - name: CI Examples Telink
               shell: bash
               run: |

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -111,7 +111,7 @@ jobs:
                 platform: telink
             - name: Update Zephyr to specific revision (for developers purpose)
               shell: bash
-              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 5e1c91c9fb0c0a9b32bb075283e5f7cb77606d74"
+              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 83e187168d097ce157972dbc92aeff888bf84d74"
             - name: CI Examples Telink
               shell: bash
               run: |

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -111,7 +111,7 @@ jobs:
                 platform: telink
             - name: Update Zephyr to specific revision (for developers purpose)
               shell: bash
-              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 83e187168d097ce157972dbc92aeff888bf84d74"
+              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py b8320f9853c629f627389ed87eb16149d1e05a5c"
             - name: CI Examples Telink
               shell: bash
               run: |

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -58,7 +58,7 @@ jobs:
                 gh-context: ${{ toJson(github) }}
 
             - name: Update Zephyr to specific revision (for developers purpose)
-              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 83e187168d097ce157972dbc92aeff888bf84d74"
+              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py b8320f9853c629f627389ed87eb16149d1e05a5c"
 
             - name: Build example Telink (B92 retention) Air Quality Sensor App
               # Run test for master and s07641069 PRs
@@ -179,18 +179,18 @@ jobs:
               run: rm -rf ./out/telink*
 
             # tl321x_retention is not supported by the Zephyr 3.7 version
-            - name: Build example Telink (tl321x_retention) Light Switch App with OTA, Shell, Factory Data
-              # Run test for master and all PRs
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --target 'telink-tl3218x_retention-light-switch-ota-shell-factory-data' build"
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    telink tl3218x_retention light-switch-app-ota-shell-factory-data \
-                    out/telink-tl3218x_retention-light-switch-ota-shell-factory-data/zephyr/zephyr.elf \
-                    /tmp/bloat_reports/
+            # - name: Build example Telink (tl321x_retention) Light Switch App with OTA, Shell, Factory Data
+            #   # Run test for master and all PRs
+            #   run: |
+            #       ./scripts/run_in_build_env.sh \
+            #         "./scripts/build/build_examples.py --target 'telink-tl3218x_retention-light-switch-ota-shell-factory-data' build"
+            #       .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+            #         telink tl3218x_retention light-switch-app-ota-shell-factory-data \
+            #         out/telink-tl3218x_retention-light-switch-ota-shell-factory-data/zephyr/zephyr.elf \
+            #         /tmp/bloat_reports/
 
-            - name: clean out build output (keep tools)
-              run: rm -rf ./out/telink*
+            # - name: clean out build output (keep tools)
+            #   run: rm -rf ./out/telink*
 
             - name: Build example Telink (tl721x) Lighting App with OTA, Shell, Factory Data
               # Run test for master and all PRs

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -58,7 +58,7 @@ jobs:
                 gh-context: ${{ toJson(github) }}
 
             - name: Update Zephyr to specific revision (for developers purpose)
-              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py b8320f9853c629f627389ed87eb16149d1e05a5c"
+              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py e8f404c8dd3ddca76e862fbfd395f2b38fabc8b5"
 
             - name: Build example Telink (B92 retention) Air Quality Sensor App
               # Run test for master and s07641069 PRs

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -58,7 +58,7 @@ jobs:
                 gh-context: ${{ toJson(github) }}
 
             - name: Update Zephyr to specific revision (for developers purpose)
-              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 5e1c91c9fb0c0a9b32bb075283e5f7cb77606d74"
+              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 83e187168d097ce157972dbc92aeff888bf84d74"
 
             - name: Build example Telink (B92 retention) Air Quality Sensor App
               # Run test for master and s07641069 PRs
@@ -179,18 +179,18 @@ jobs:
               run: rm -rf ./out/telink*
 
             # tl321x_retention is not supported by the Zephyr 3.7 version
-            # - name: Build example Telink (tl321x_retention) Light Switch App with OTA, Shell, Factory Data
-            #   # Run test for master and all PRs
-            #   run: |
-            #       ./scripts/run_in_build_env.sh \
-            #         "./scripts/build/build_examples.py --target 'telink-tl3218x_retention-light-switch-ota-shell-factory-data' build"
-            #       .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-            #         telink tl3218x_retention light-switch-app-ota-shell-factory-data \
-            #         out/telink-tl3218x_retention-light-switch-ota-shell-factory-data/zephyr/zephyr.elf \
-            #         /tmp/bloat_reports/
+            - name: Build example Telink (tl321x_retention) Light Switch App with OTA, Shell, Factory Data
+              # Run test for master and all PRs
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                    "./scripts/build/build_examples.py --target 'telink-tl3218x_retention-light-switch-ota-shell-factory-data' build"
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                    telink tl3218x_retention light-switch-app-ota-shell-factory-data \
+                    out/telink-tl3218x_retention-light-switch-ota-shell-factory-data/zephyr/zephyr.elf \
+                    /tmp/bloat_reports/
 
-            # - name: clean out build output (keep tools)
-            #   run: rm -rf ./out/telink*
+            - name: clean out build output (keep tools)
+              run: rm -rf ./out/telink*
 
             - name: Build example Telink (tl721x) Lighting App with OTA, Shell, Factory Data
               # Run test for master and all PRs

--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -304,11 +304,11 @@ config CHIP_ENABLE_ICD_SUPPORT
     default y if CHIP_THREAD_DEVICE_ROLE_SLEEPY_END_DEVICE
 
 config OPENTHREAD_CSMABACKOFF_OPTIMIZATION
-	bool "Skip the first backoff during sending data request"
+	bool "Skip initial CSMA-CA backoff when sending data requests"
 	depends on CHIP_ENABLE_ICD_SUPPORT
 	default n
 	help
-	  Help save idle time during IEEE 802.15.4 communication
+	  Skip the first CSMA backoff period when sending data requests over IEEE 802.15.4.
 
 config IEEE802154_TLX_OPTIMIZATION
 	bool "Optimize 802.15.4 RF performance for TLX SoCs"

--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -88,7 +88,9 @@ config HEAP_MEM_POOL_SIZE
     default 1280
 
 config COMMON_LIBC_MALLOC_ARENA_SIZE
-    default 20716 if SOC_SERIES_RISCV_TELINK_B9X_RETENTION || (SOC_RISCV_TELINK_TL321X && ZEPHYR_VERSION_3_3)
+    default 20716 if SOC_SERIES_RISCV_TELINK_B9X_RETENTION || \
+                     (SOC_RISCV_TELINK_TL321X && ZEPHYR_VERSION_3_3) || \
+                     (SOC_RISCV_TELINK_TL721X && SOC_SERIES_RISCV_TELINK_TLX_RETENTION && ZEPHYR_VERSION_3_3)
     default 16384 if SOC_RISCV_TELINK_TL721X || (SOC_RISCV_TELINK_TL321X && !ZEPHYR_VERSION_3_3)
     default 12288
 
@@ -300,6 +302,17 @@ endchoice
 
 config CHIP_ENABLE_ICD_SUPPORT
     default y if CHIP_THREAD_DEVICE_ROLE_SLEEPY_END_DEVICE
+
+config OPENTHREAD_CSMABACKOFF_OPTIMIZATION
+	bool "Skip the first backoff during sending data request"
+	depends on CHIP_ENABLE_ICD_SUPPORT
+	default n
+
+config IEEE802154_TLX_OPTIMIZATION
+	bool "optimize the rf performance for tlx"
+	default n
+	help
+	  optimize the rf performance for tlx.
 
 config OPENTHREAD_THREAD_STACK_SIZE
     default 2400 if PM || SOC_RISCV_TELINK_TL321X

--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -90,7 +90,7 @@ config HEAP_MEM_POOL_SIZE
 config COMMON_LIBC_MALLOC_ARENA_SIZE
     default 20716 if SOC_SERIES_RISCV_TELINK_B9X_RETENTION || \
                      (SOC_RISCV_TELINK_TL321X && ZEPHYR_VERSION_3_3) || \
-                     (SOC_RISCV_TELINK_TL721X && SOC_SERIES_RISCV_TELINK_TLX_RETENTION && ZEPHYR_VERSION_3_3)
+                     (SOC_RISCV_TELINK_TL721X && SOC_SERIES_RISCV_TELINK_TLX_RETENTION)
     default 16384 if SOC_RISCV_TELINK_TL721X || (SOC_RISCV_TELINK_TL321X && !ZEPHYR_VERSION_3_3)
     default 12288
 
@@ -307,12 +307,14 @@ config OPENTHREAD_CSMABACKOFF_OPTIMIZATION
 	bool "Skip the first backoff during sending data request"
 	depends on CHIP_ENABLE_ICD_SUPPORT
 	default n
+	help
+	  Help save idle time during IEEE 802.15.4 communication
 
 config IEEE802154_TLX_OPTIMIZATION
-	bool "optimize the rf performance for tlx"
+	bool "Optimize 802.15.4 RF performance for TLX SoCs"
 	default n
 	help
-	  optimize the rf performance for tlx.
+	  Improve RF performance in IEEE 802.15.4 communication on TLX SoCs.
 
 config OPENTHREAD_THREAD_STACK_SIZE
     default 2400 if PM || SOC_RISCV_TELINK_TL321X


### PR DESCRIPTION
- OPENTHREAD_CSMABACKOFF_OPTIMIZATION
- IEEE802154_TLX_OPTIMIZATION

and set COMMON_LIBC_MALLOC_ARENA_SIZE to 20kb if tl7218x_retention for power consumption optimization based on d6882ec0719692a1ef1bc983e138f32bf1a39442.

- The first commit (f5342e56dcf282a76d3dcec552ab7e006bf032d9) is only suitable for Zephyr V3.3 ( https://github.com/telink-semi/zephyr/pull/488 - passed and merged to develop_v3.3 - Note that I did manually squash so the actual commit hash is [86fcdb43b64d6d10ad81172c61495c9e40de0403 ](https://github.com/telink-semi/zephyr/tree/develop_v3.3)  )

- The second commit (61263b0304c1508491181760d53d405f824d029b) does not work for tl7218x_retention as it cannot complete commissioning due to the limit of LIBC allocation size 16kB.

- The third commit (dfabb0e35f6f13cf40bfc1bd3eeb9f8d825345d5) increases the limit to 20kB for tl7218x_retention while it maintains 16kB for tl7218kB so it is compatible for both Zephyr V3.3 and V3.7 (https://github.com/telink-semi/zephyr/pull/491 - passed and merged to develop)

- The fourth commit (1cf5186db505e2c9185986e6394504134c87179e) updates the description of the newly added configs and the Zephyr V3.7 revision after https://github.com/telink-semi/zephyr/pull/491 is merged.

#### Testing
Verified by CI
