### PR TITLE
[Telink] Add fallback for __errno symbol when using picolibc

### DIFF
--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -58,7 +58,7 @@ jobs:
                 gh-context: ${{ toJson(github) }}
 
             - name: Update Zephyr version 4.1.0 (develop) to specific revision (for developers purpose)
-              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 4b909d41ac1af033bd99311172c6f2b1a625e59c"
+              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 1cedc0b7af87e96ed9d261b15ff654389c1c6325"
 
             - name: Build example Telink (B92 retention) Air Quality Sensor App
               # Run test for master and s07641069 PRs
@@ -197,10 +197,10 @@ jobs:
               if: github.event.pull_request.number == null || github.event.pull_request.head.repo.full_name == 's07641069/connectedhomeip'
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --target 'telink-tl7218x-light-tflm-newlib' build"
+                    "./scripts/build/build_examples.py --target 'telink-tl7218x-light-tflm' build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    telink tl7218x light-app-tflm-newlib \
-                    out/telink-tl7218x-light-tflm-newlib/zephyr/zephyr.elf \
+                    telink tl7218x light-app-tflm \
+                    out/telink-tl7218x-light-tflm/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
 
             - name: clean out build output (keep tools)
@@ -392,7 +392,7 @@ jobs:
                 gh-context: ${{ toJson(github) }}
 
             - name: Update Zephyr version 3.3.0 (develop_3.3) to specific revision (for developers purpose)
-              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py a39f1e8426453d37da8a1dd41e44efb8c7887d31"
+              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py c590256b7947aea278ad462aa50de6d56f753ff8"
 
             - name: Build example Telink (B92 retention) Air Quality Sensor App
               # Run test for master and s07641069 PRs

--- a/examples/lighting-app/telink/CMakeLists.txt
+++ b/examples/lighting-app/telink/CMakeLists.txt
@@ -74,7 +74,8 @@ if(CONFIG_TFLM_FEATURE)
                  src/tflm/models/micro_speech_quantized_model_data.h
                  src/tflm/micro_speech/micro_model_settings.h
                  src/tflm/micro_speech/tflite_micro_micro_speech.cpp
-                 src/tflm/micro_speech/tflite_micro_micro_speech.h)
+                 src/tflm/micro_speech/tflite_micro_micro_speech.h
+                 src/tflm/errno_stub.c)
 endif()
 
 chip_configure_data_model(app

--- a/examples/lighting-app/telink/src/tflm/errno_stub.c
+++ b/examples/lighting-app/telink/src/tflm/errno_stub.c
@@ -1,0 +1,24 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <errno.h>
+
+/* This implementation provides a fallback for __errno symbol when using picolibc. */
+int *__errno(void) {
+    return &errno;
+}

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -823,7 +823,6 @@ def BuildTelinkTarget():
     target.AppendModifier('thread-analyzer', thread_analyzer_config=True)
     target.AppendModifier('precompiled-ot', precompiled_ot_config=True)
     target.AppendModifier('tflm', tflm_config=True)
-    target.AppendModifier('newlib', newlib_libc_config=True)
 
     return target
 

--- a/scripts/build/builders/telink.py
+++ b/scripts/build/builders/telink.py
@@ -164,7 +164,6 @@ class TelinkBuilder(Builder):
                  thread_analyzer_config: bool = False,
                  precompiled_ot_config: bool = False,
                  tflm_config: bool = False,
-                 newlib_libc_config: bool = False,
                  ):
         super(TelinkBuilder, self).__init__(root, runner)
         self.app = app
@@ -181,7 +180,6 @@ class TelinkBuilder(Builder):
         self.thread_analyzer_config = thread_analyzer_config
         self.precompiled_ot_config = precompiled_ot_config
         self.tflm_config = tflm_config
-        self.newlib_libc_config = newlib_libc_config
 
     def get_cmd_prefixes(self):
         if not self._runner.dry_run:
@@ -237,9 +235,6 @@ class TelinkBuilder(Builder):
 
         if self.tflm_config:
             flags.append("-DCONFIG_TFLM_FEATURE=y")
-
-        if self.newlib_libc_config:
-            flags.append("-DCONFIG_NEWLIB_LIBC=y")
 
         if self.options.pregen_dir:
             flags.append(f"-DCHIP_CODEGEN_PREGEN_DIR={shlex.quote(self.options.pregen_dir)}")

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -23,5 +23,5 @@ qpg-qpg6105-{light,light-switch,lock,persistent-storage,shell,thermostat}[-updat
 realtek-rtl8777g-{all-clusters,light-switch,lighting,lock,ota-requestor,thermostat,window}
 stm32-stm32wb5mm-dk-light
 tizen-{arm,arm64}-{all-clusters,chip-tool,light,tests}[-asan][-coverage][-no-ble][-no-thread][-no-wifi][-ubsan][-with-ui]
-telink-{tl3218x,tl3218x_retention,tl7218x,tl7218x_retention,tlsr9118bdk40d,tlsr9518adk80d,tlsr9528a,tlsr9528a_retention}-{air-quality-sensor,all-clusters,all-clusters-minimal,bridge,contact-sensor,light,light-switch,lock,ota-requestor,pump,pump-controller,shell,smoke-co-alarm,temperature-measurement,thermostat,window-covering}[-4mb][-compress-lzma][-dfu][-factory-data][-mars][-newlib][-ota][-precompiled-ot][-rpc][-shell][-tflm][-thread-analyzer][-usb]
+telink-{tl3218x,tl3218x_retention,tl7218x,tl7218x_retention,tlsr9118bdk40d,tlsr9518adk80d,tlsr9528a,tlsr9528a_retention}-{air-quality-sensor,all-clusters,all-clusters-minimal,bridge,contact-sensor,light,light-switch,lock,ota-requestor,pump,pump-controller,shell,smoke-co-alarm,temperature-measurement,thermostat,window-covering}[-4mb][-compress-lzma][-dfu][-factory-data][-mars][-ota][-precompiled-ot][-rpc][-shell][-tflm][-thread-analyzer][-usb]
 openiotsdk-{lock,shell}[-mbedtls][-psa]


### PR DESCRIPTION
**Change overview**

- Avoid using newlibc instead of picolibc
- Add fallback for __errno symbol when using picolibc
- Remove newlib target

Related PR (Zephyr v3.7): https://github.com/project-chip/connectedhomeip/pull/39072

#### Testing
Verified by GitHub CI