### PR TITLE
riscv: telink: fix dnss exception trigger when dfu-ota

### DIFF
--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -173,7 +173,9 @@ user_para_t user_para;
 const struct device * flash_para_dev = DUAL_MODE_PARTITION_DEVICE;
 const struct device * zb_para_dev    = ZB_NVS_PARTITION_DEVICE;
 constexpr int kDnssTimeout           = 60000;
-static k_timer sDnssTimer;
+#if !CONFIG_MCUMGR_TRANSPORT_BT
+static k_timer sDnssTimer; // create when dfu disable
+#endif /* !CONFIG_MCUMGR_TRANSPORT_BT */
 
 void FactoryResetExtHandler(void)
 {

--- a/examples/platform/telink/util/include/DFUOverSMP.h
+++ b/examples/platform/telink/util/include/DFUOverSMP.h
@@ -27,6 +27,16 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/storage/flash_map.h>
 
+#if CONFIG_DUAL_MODE == CONFIG_AUTO_SWITCH_DUAL_MODE
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern struct k_timer sDnssTimer;
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* CONFIG_AUTO_SWITCH_DUAL_MODE */
+
 enum VerificationFailReason : unsigned char
 {
     NO_FAIL          = 0,

--- a/examples/platform/telink/util/src/DFUOverSMP.cpp
+++ b/examples/platform/telink/util/src/DFUOverSMP.cpp
@@ -36,6 +36,17 @@
 
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
+#if CONFIG_DUAL_MODE == CONFIG_AUTO_SWITCH_DUAL_MODE
+#ifdef __cplusplus
+extern "C" {
+#endif
+struct k_timer sDnssTimer;
+static volatile bool canlTimerFlag = false;
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* CONFIG_AUTO_SWITCH_DUAL_MODE */
+
 static void reboot_work_handler(struct k_work * work)
 {
     LOG_INF("[DFU] Start reboot!");
@@ -55,6 +66,13 @@ int UploadProgressHandler(uint32_t event, int32_t rc, bool * abort_more, void * 
 #endif
 
 {
+#if CONFIG_DUAL_MODE == CONFIG_AUTO_SWITCH_DUAL_MODE
+    if (!canlTimerFlag) {
+        k_timer_stop(&sDnssTimer);
+        canlTimerFlag = true;
+        LOG_INF("[Telink] DnssTimer stopped; DFU-OTA Handler.\n");
+    }
+#endif /* CONFIG_AUTO_SWITCH_DUAL_MODE */
     const img_mgmt_upload_check & imgData = *static_cast<img_mgmt_upload_check *>(data);
 
     LOG_INF("[DFU] DFU over SMP progress: %u/%u B of image %u", static_cast<unsigned>(imgData.req->off),


### PR DESCRIPTION
 - Stopping sDnssTimer when duf-ota start .

> !!!!!!!!!! Please delete the instructions below and replace with PR description
>
> If you have an issue number, please use a syntax of
> `Fixes #12345` and a brief change description
>
> If you do not have an issue number, please have a good description of
> the problem and the fix. Help the reviewer understand what to expect.
>
> Make sure you delete these instructions (to prove you have read them).
>
> !!!!!!!!!! Instructions end

