### PR TITLE
[Telink] Fix CNET 4.12 thread switching

### DIFF
--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -1048,6 +1048,14 @@ BLEManagerImpl::HandleOperationalNetworkEnabled(const ChipDeviceEvent * event)
     ChipLogDetail(DeviceLayer, "HandleOperationalNetworkEnabled");
 
     CHIP_ERROR error = CHIP_NO_ERROR;
+    if (!ThreadStackMgrImpl().IsReadyToAttach())
+    {
+        // Ignore operational-network notifications once the one-time BLE->Thread
+        // handoff is complete. Pure Thread-to-Thread switches should be handled
+        // by the Thread stack directly.
+        return CHIP_NO_ERROR;
+    }
+
     /* On first commissioning BLE disconnects before switching to Thread operational network.
        All subsequent Thread operational network changes are handled in a bit different way */
     if (!mReadyToAttachThread)
@@ -1071,7 +1079,6 @@ BLEManagerImpl::HandleOperationalNetworkEnabled(const ChipDeviceEvent * event)
         error = PlatformMgr().PostEvent(&attachEvent);
         VerifyOrExit(error == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "PostEvent err: %" CHIP_ERROR_FORMAT, error.Format()));
 
-        TEMPORARY_RETURN_IGNORED ThreadStackMgrImpl().CommitConfiguration();
     }
 
 exit:
@@ -1105,6 +1112,7 @@ void BLEManagerImpl::SwitchToIeee802154(void)
     // Init Thread
     ThreadStackMgrImpl().SetRadioBlocked(false);
     TEMPORARY_RETURN_IGNORED ThreadStackMgrImpl().SetThreadEnabled(true);
+    ThreadStackMgrImpl().SetReadyToAttach(false);
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 

--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -1078,7 +1078,6 @@ BLEManagerImpl::HandleOperationalNetworkEnabled(const ChipDeviceEvent * event)
 
         error = PlatformMgr().PostEvent(&attachEvent);
         VerifyOrExit(error == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "PostEvent err: %" CHIP_ERROR_FORMAT, error.Format()));
-
     }
 
 exit:

--- a/src/platform/telink/ThreadStackManagerImpl.cpp
+++ b/src/platform/telink/ThreadStackManagerImpl.cpp
@@ -103,6 +103,17 @@ ThreadStackManagerImpl::_AttachToThreadNetwork(const Thread::OperationalDataset 
     if (dataset.AsByteSpan().data_equal(current_dataset.AsByteSpan()) && callback == nullptr)
         return CHIP_NO_ERROR;
 
+    if (dataset.IsCommissioned() && current_dataset.IsCommissioned() && !dataset.AsByteSpan().data_equal(current_dataset.AsByteSpan()) &&
+        IsThreadEnabled())
+    {
+        result = SetThreadProvision(dataset.AsByteSpan());
+        if (result == CHIP_NO_ERROR && callback != nullptr)
+        {
+            callback->OnResult(NetworkCommissioning::Status::kSuccess, CharSpan(), 0);
+        }
+        return result;
+    }
+
     if (mRadioBlocked || mReadyToAttach)
     {
         /* On Telink platform it's not possible to rise Thread network when its used by BLE,
@@ -111,7 +122,10 @@ ThreadStackManagerImpl::_AttachToThreadNetwork(const Thread::OperationalDataset 
         if (result == CHIP_NO_ERROR)
         {
             mReadyToAttach = true;
-            callback->OnResult(NetworkCommissioning::Status::kSuccess, CharSpan(), 0);
+            if (callback != nullptr)
+            {
+                callback->OnResult(NetworkCommissioning::Status::kSuccess, CharSpan(), 0);
+            }
         }
     }
     else

--- a/src/platform/telink/ThreadStackManagerImpl.cpp
+++ b/src/platform/telink/ThreadStackManagerImpl.cpp
@@ -103,8 +103,8 @@ ThreadStackManagerImpl::_AttachToThreadNetwork(const Thread::OperationalDataset 
     if (dataset.AsByteSpan().data_equal(current_dataset.AsByteSpan()) && callback == nullptr)
         return CHIP_NO_ERROR;
 
-    if (dataset.IsCommissioned() && current_dataset.IsCommissioned() && !dataset.AsByteSpan().data_equal(current_dataset.AsByteSpan()) &&
-        IsThreadEnabled())
+    if (dataset.IsCommissioned() && current_dataset.IsCommissioned() &&
+        !dataset.AsByteSpan().data_equal(current_dataset.AsByteSpan()) && IsThreadEnabled())
     {
         result = SetThreadProvision(dataset.AsByteSpan());
         if (result == CHIP_NO_ERROR && callback != nullptr)

--- a/src/platform/telink/ThreadStackManagerImpl.h
+++ b/src/platform/telink/ThreadStackManagerImpl.h
@@ -60,6 +60,7 @@ public:
     // ===== Methods that implement the ThreadStackManager abstract interface.
     CHIP_ERROR _InitThreadStack();
     void SetRadioBlocked(bool state) { mRadioBlocked = state; }
+    void SetReadyToAttach(bool state) { mReadyToAttach = state; }
     bool IsReadyToAttach(void) const { return mReadyToAttach; }
     void Finalize(void);
     CHIP_ERROR CommitConfiguration(void);


### PR DESCRIPTION
### Summary

This change fixes Telink-specific Thread network switching issues that show up in `TC-CNET-4.12` on this branch.
On `master` we've already fixed this in #43562.

On this branch we still have a platform-specific BLE/Thread handoff path for single-radio behavior. That path was interfering with normal Thread-to-Thread transitions in two ways:

1. It could delete the fail-safe backup too early during operational network handoff, which prevented rollback to the previous Thread dataset on fail-safe expiry.
2. It could still route later Thread-to-Thread `ConnectNetwork` calls through logic intended only for the initial BLE-to-Thread transition, which caused the active CASE session to be dropped before the `ConnectNetworkResponse` was sent.

The result was:
- fail-safe rollback staying on the second dataset instead of returning to the first one
- `ConnectNetwork` over CASE failing during Thread dataset switch because the response was sent after the old Thread path was already torn down

### What Changed

#### `src/platform/telink/BLEManagerImpl.cpp`
- Stop calling `ThreadStackMgrImpl().CommitConfiguration()` from `HandleOperationalNetworkEnabled()`.
  - Network Commissioning already owns commit/revert timing.
  - Keeping this extra commit in the Telink BLE handoff path removed the stored fail-safe backup too early.
- Ignore `kOperationalNetworkEnabled` once there is no pending deferred BLE-to-Thread attach.
  - This keeps the one-time BLE handoff logic from running again during later pure Thread-to-Thread transitions.
- Clear the Telink deferred-attach state after switching back to Thread.

#### `src/platform/telink/ThreadStackManagerImpl.cpp`
- Add a fast path for commissioned Thread-to-Thread dataset switching while Thread is already enabled.
  - Instead of disabling and re-enabling Thread, update the active dataset directly with `SetThreadProvision(...)`.
- Use that path for both:
  - internal restore / rollback (`callback == nullptr`)
  - normal callback-driven `ConnectNetwork`
- Keep callback handling null-safe for internal restore paths.

#### `src/platform/telink/ThreadStackManagerImpl.h`
- Add a small setter to allow the BLE manager to clear the deferred-attach flag after the BLE-to-Thread handoff is complete.

### Why This Is Needed

This branch still carries Telink-specific single-radio behavior that no longer matches the newer upstream structure on `master`.

For `TC-CNET-4.12`, we need two things to work reliably on this branch:
- fail-safe rollback between commissioned Thread datasets
- CASE `ConnectNetwork` response delivery during a Thread-to-Thread transition

Without these Telink-side fixes:
- rollback can no longer restore the previous dataset because the backup gets committed away too early
- CASE `ConnectNetwork` can lose the active operational path before the response is sent

These changes keep the fix local to the Telink override layer and avoid pulling in the broader non-concurrent `NetworkCommissioningCluster` changes that were not needed for the passing path on this branch.

### Behavior After This Change

- Fail-safe expiry restores the previous Thread dataset correctly.
- Thread-to-Thread `ConnectNetwork` over CASE can complete without tearing down the active Thread path before the response is sent.
- The special BLE-to-Thread handoff logic only runs for the actual deferred attach case and does not interfere with later operational Thread switches.

### Testing

- Verified against `TC-CNET-4.12` on tl3238x with python testing harness with:
```
python3 src/python_testing/TC_CNET_4_12.py \
  --storage-path /work/connectedhomeip/.state/cnet412_admin_storage.json \
  --logs-path /tmp/cnet412_logs \
  --trace-to json:/tmp/cnet412_trace.json \
  --timeout 1800 \
  --PICS src/app/tests/suites/certification/ci-pics-values \
  --commissioning-method ble-thread \
  --discriminator 3840 \
  --passcode 20202021 \
  --dut-node-id 0x12344321 \
  --endpoint 0 \
  --thread-dataset-hex 0e0800000000000100004a0300000f35060004001fffe00708fd186b4dcaba1e060c0402a0f7f8051000112233445566778899aabbccddeefa03094f5442525f52504933041008f3a4cefc99e588e8af8829bdfa49fb00030000190208111111112222222101021234\
  --string-arg PIXIT.CNET.THREAD_2ND_OPERATIONALDATASET:0e0800000000000100004a0300001635060004001fffe00708fdacfc0c6c61452d0c0402a0f7f8051000112233445566778899aabbccddeeff03094f5442525f5250493404109d92be71b406d7295da1271aaeff8f5f000300000f0208111111112222222201022222
```