### PR TITLE
[Telink] Fix TC-OPCREDS-3.6 test (#43028)

### DIFF
--- a/config/telink/chip-module/Kconfig
+++ b/config/telink/chip-module/Kconfig
@@ -284,13 +284,14 @@ config CHIP_PERSISTENT_SUBSCRIPTIONS
 	# selecting experimental for this feature since there is an issue with multiple controllers.
 	select EXPERIMENTAL
 
-if CHIP_PERSISTENT_SUBSCRIPTIONS
-
 config CHIP_MAX_FABRICS
 	int "Maximum number of Matter fabrics"
+	default 3 if BOARD_TL3218X_RETENTION
 	default 5
 	help
 	  The maximum number of Matter fabrics that device can be joined to.
+
+if CHIP_PERSISTENT_SUBSCRIPTIONS
 
 config CHIP_MAX_ACTIVE_CASE_CLIENTS
 	int "Maximum number of outgoing CASE sessions"

--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -279,6 +279,10 @@ config NVS_LOOKUP_CACHE_SIZE
 config SETTINGS_NVS_SECTOR_SIZE_MULT
     default 1
 
+# Enable extended discovery
+config CHIP_EXTENDED_DISCOVERY
+    default y
+
 # Enable OpenThread
 config NET_L2_OPENTHREAD
     default y if !WIFI

--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -318,51 +318,48 @@ public:
 AppCallbacks sCallbacks;
 } // namespace
 
+static void DoDelayedFactoryReset(struct k_work * work)
+{
+    ChipLogProgress(DeviceLayer, "Erasing settings partition");
+
+    // TC-OPCREDS-3.6 (device doesn't need to reboot automatically after the last fabric is removed) can't use FactoryReset
+    void * storage = nullptr;
+    int status     = settings_storage_get(&storage);
+
+    if (!status)
+    {
+        status = nvs_clear(static_cast<nvs_fs *>(storage));
+    }
+
+    if (!status)
+    {
+        status = nvs_mount(static_cast<nvs_fs *>(storage));
+    }
+
+    if (status)
+    {
+        ChipLogError(DeviceLayer, "Storage clear failed: %d", status);
+    }
+#ifdef CONFIG_TFLM_FEATURE
+    AppTask::MicroSpeechProcessStop();
+#endif
+    // Reboot in case of failed commissioning to allow new pairing via BLE
+    if (sIsCommissioningFailed)
+    {
+        ChipLogProgress(DeviceLayer, "Rebooting board");
+        sys_reboot(SYS_REBOOT_WARM);
+    }
+}
+
+static k_work_delayable sDelayedFactoryResetWork = Z_WORK_DELAYABLE_INITIALIZER(DoDelayedFactoryReset);
+
 class AppFabricTableDelegate : public FabricTable::Delegate
 {
     void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex)
     {
         if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0)
         {
-            ChipLogProgress(DeviceLayer, "Erasing settings partition");
-
-            // TC-OPCREDS-3.6 (device doesn't need to reboot automatically after the last fabric is removed) can't use FactoryReset
-            void * storage = nullptr;
-            int status     = settings_storage_get(&storage);
-
-            if (!status)
-            {
-                status = nvs_clear(static_cast<nvs_fs *>(storage));
-            }
-
-            if (!status)
-            {
-                status = nvs_mount(static_cast<nvs_fs *>(storage));
-            }
-
-            if (status)
-            {
-                ChipLogError(DeviceLayer, "Storage clear failed: %d", status);
-            }
-#ifdef CONFIG_TFLM_FEATURE
-            AppTask::MicroSpeechProcessStop();
-#endif
-            // Reboot in case of failed commissioning to allow new pairing via BLE
-            if (sIsCommissioningFailed)
-            {
-                ChipLogProgress(DeviceLayer, "Rebooting board");
-                sys_reboot(SYS_REBOOT_WARM);
-            }
-            else
-            {
-                #if CONFIG_DUAL_MODE == CONFIG_ACTION_DUAL_MODE
-                dual_mode_switch(OPCODE_FACTORY_RESET);
-                #elif CONFIG_DUAL_MODE == CONFIG_AUTO_SWITCH_DUAL_MODE
-                dual_mode_auto_switch(OPCODE_FACTORY_RESET);
-                #endif
-                ChipLogProgress(DeviceLayer, "Do factory_reset and reboot");
-                chip::Server::GetInstance().ScheduleFactoryReset();
-            }
+            k_work_schedule(&sDelayedFactoryResetWork, K_SECONDS(2));
         }
     }
 };


### PR DESCRIPTION
### Summary

* [Telink] Fix TC-OPCREDS-3.6 test

* Restyled by clang-format

* [Telink] Decrease CHIP_MAX_FABRICS for BOARD_TL3218X_RETENTION.

* [Telink] Fix default value for BOARD_TL3218X_RETENTION

### Testing

- Verified against `TC-OPCREDS-3.6` on tl3238x with manually testing.
