### PR TITLE
telink: 3238x: fix factory reset logic for commissioned device.

### DIFF
--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -349,6 +349,16 @@ static void DoDelayedFactoryReset(struct k_work * work)
         ChipLogProgress(DeviceLayer, "Rebooting board");
         sys_reboot(SYS_REBOOT_WARM);
     }
+    else
+    {
+        #if CONFIG_DUAL_MODE == CONFIG_ACTION_DUAL_MODE
+        dual_mode_switch(OPCODE_FACTORY_RESET);
+        #elif CONFIG_DUAL_MODE == CONFIG_AUTO_SWITCH_DUAL_MODE
+        dual_mode_auto_switch(OPCODE_FACTORY_RESET);
+        #endif
+        ChipLogProgress(DeviceLayer, "Do factory_reset and reboot");
+        chip::Server::GetInstance().ScheduleFactoryReset();
+    }
 }
 
 static k_work_delayable sDelayedFactoryResetWork = Z_WORK_DELAYABLE_INITIALIZER(DoDelayedFactoryReset);


### PR DESCRIPTION
### Summary

- fix incorrect factory reset logic for commissioned device when fabric is 0.
- fix https://github.com/s07641069/connectedhomeip/pull/444


### Testing

- Verified on tl3238x_retention with chip-tool and apple.
- chip-tool:  `./chip-tool operationalcredentials remove-fabric 1 1 0`
  - Result: TCP connection is not present, device will perform factory reset and starts BLE broadcasting.
- apple: When device is removed by Apple, factory reset will be automatically performed.