### PR TITLE
Select Correct OpenThread Path based on CONFIG_OPENTHREAD_TELINK_LIBRARY

### DIFF
--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -58,7 +58,7 @@ jobs:
                 gh-context: ${{ toJson(github) }}
 
             - name: Update Zephyr version 4.1.0 (develop) to specific revision (for developers purpose)
-              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py d31d26afcd55cea3b43df82dbd51ecefeedf8993"
+              run: scripts/run_in_build_env.sh "python3 scripts/tools/telink/update_zephyr.py 3a3683860df05a6e9d441a66f50097c9c03258bb"
 
             - name: Build tools required for Factory Data
               # Run test for master and all PRs

--- a/config/telink/chip-module/CMakeLists.txt
+++ b/config/telink/chip-module/CMakeLists.txt
@@ -71,7 +71,10 @@ matter_add_flags(-DMBEDTLS_USER_CONFIG_FILE=<${CONFIG_MBEDTLS_CFG_FILE}>)
 
 if (CONFIG_OPENTHREAD_TELINK_LIBRARY)
     set(ZEPHYR_OPENTHREAD_MODULE_DIR ${ZEPHYR_BASE}/../modules/lib/openthread_telink_lib CACHE STRING INTERNAL)
-	message(STATUS "OpenThread used as precompiled Telink library, path: ${ZEPHYR_OPENTHREAD_MODULE_DIR}")
+    message(STATUS "OpenThread used as precompiled Telink library, path: ${ZEPHYR_OPENTHREAD_MODULE_DIR}")
+else()
+    set(ZEPHYR_OPENTHREAD_MODULE_DIR ${ZEPHYR_BASE}/../modules/lib/openthread CACHE STRING INTERNAL)
+    message(STATUS "OpenThread used from source, path: ${ZEPHYR_OPENTHREAD_MODULE_DIR}")
 endif()
 
 if (CONFIG_CHIP_OPENTHREAD_CONFIG)

--- a/examples/platform/telink/build_info.cmake
+++ b/examples/platform/telink/build_info.cmake
@@ -109,10 +109,64 @@ else()
     set(TELINK_HAL_LOCAL_STATUS "")
 endif()
 
+# OpenThread info
+if(CONFIG_OPENTHREAD_TELINK_LIBRARY)
+  set(OPENTHREAD_PATH "${ZEPHYR_BASE}/../modules/lib/openthread_telink_lib")
+else()
+  set(OPENTHREAD_PATH "${ZEPHYR_BASE}/../modules/lib/openthread")
+endif()
+
+execute_process(
+    COMMAND git -C ${OPENTHREAD_PATH} rev-parse HEAD
+    OUTPUT_VARIABLE OT_COMMIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
+execute_process(
+    COMMAND git -C ${OPENTHREAD_PATH} rev-parse --abbrev-ref HEAD
+    OUTPUT_VARIABLE OT_BRANCH_NAME
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
+execute_process(
+    COMMAND git -C ${OPENTHREAD_PATH} show -s --format=%cd --date=format:%Y-%m-%d HEAD
+    OUTPUT_VARIABLE OT_COMMIT_DATE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
+execute_process(
+    COMMAND bash -c "git -C ${OPENTHREAD_PATH} remote get-url \$(git -C ${OPENTHREAD_PATH} remote | head -n 1)"
+    OUTPUT_VARIABLE OT_REMOTE_URL
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
+execute_process(
+    COMMAND git -C ${OPENTHREAD_PATH} diff --quiet
+    RESULT_VARIABLE OT_LOCAL_STATUS
+    ERROR_QUIET
+)
+
+if(OT_LOCAL_STATUS)
+    set(OT_LOCAL_STATUS "-dirty")
+else()
+    set(OT_LOCAL_STATUS "")
+endif()
+
 execute_process(
     COMMAND git -C ${ZEPHYR_BASE}/../modules/hal/telink show -s --format=%cd --date=format:%Y-%m-%d
     OUTPUT_VARIABLE TELINK_HAL_COMMIT_DATE
     OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+    COMMAND git -C ${OPENTHREAD_PATH} describe --tags --exact-match
+    OUTPUT_VARIABLE OT_TAG
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
 )
 
 target_compile_definitions(app PRIVATE
@@ -132,6 +186,14 @@ target_compile_definitions(app PRIVATE
   TELINK_HAL_COMMIT_HASH="${TELINK_HAL_COMMIT_HASH}"
   TELINK_HAL_LOCAL_STATUS="${TELINK_HAL_LOCAL_STATUS}"
   TELINK_HAL_COMMIT_DATE="${TELINK_HAL_COMMIT_DATE}"
+
+  OPENTHREAD_PATH="${OPENTHREAD_PATH}"
+  OT_COMMIT_HASH="${OT_COMMIT_HASH}"
+  OT_BRANCH="${OT_BRANCH_NAME}"
+  OT_COMMIT_DATE="${OT_COMMIT_DATE}"
+  OT_REMOTE_URL="${OT_REMOTE_URL}"
+  OT_LOCAL_STATUS="${OT_LOCAL_STATUS}"
+  OT_TAG="${OT_TAG}"
 )
 
 message(STATUS "Matter revision:")
@@ -146,3 +208,11 @@ message(STATUS "      remote: ${ZEPHYR_REMOTE_URL}")
 
 message(STATUS "HAL revision:")
 message(STATUS "      commit: ${TELINK_HAL_COMMIT_HASH} ${TELINK_HAL_COMMIT_DATE}")
+
+message(STATUS "OpenThread revision:")
+message(STATUS "      path: ${OPENTHREAD_PATH}")
+message(STATUS "      branch: ${OT_BRANCH_NAME} ${OT_COMMIT_HASH} ${OT_COMMIT_DATE}")
+if(OT_TAG)
+  message(STATUS "      tag: ${OT_TAG}")
+endif()
+message(STATUS "      remote: ${OT_REMOTE_URL}")

--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -500,6 +500,15 @@ void AppTaskCommon::PrintFirmwareInfo(void)
     LOG_DBG("\t branch: %s %.8s%s %s", ZEPHYR_BRANCH, ZEPHYR_COMMIT_HASH, ZEPHYR_LOCAL_STATUS, ZEPHYR_COMMIT_DATE);
     LOG_DBG("\t remote: %s", ZEPHYR_REMOTE_URL);
     LOG_DBG("\t HAL commit: %.8s%s %s", TELINK_HAL_COMMIT_HASH, TELINK_HAL_LOCAL_STATUS, TELINK_HAL_COMMIT_DATE);
+
+    LOG_DBG("OpenThread revision: ");
+    LOG_DBG("\t path: %s", OPENTHREAD_PATH);
+    LOG_DBG("\t remote: %s", OT_REMOTE_URL);
+    if (strlen(OT_TAG) > 0)
+    {
+        LOG_DBG("\t tag: %s", OT_TAG);
+    }
+    LOG_DBG("\t branch: %s %.8s%s %s", OT_BRANCH, OT_COMMIT_HASH, OT_LOCAL_STATUS, OT_COMMIT_DATE);
 #endif
 }
 CHIP_ERROR AppTaskCommon::InitCommonParts(void)


### PR DESCRIPTION
This PR is cherry-picked from https://github.com/telink-semi/connectedhomeip/pull/3.

Note the difference is setting Zephyr revision to 3a3683860df05a6e9d441a66f50097c9c03258bb in https://github.com/telink-semi/zephyr/commit/3a3683860df05a6e9d441a66f50097c9c03258bb

For details, refer to the above info.