### PR TITLE
telink: tl3238x: add commissioning flag and fix compilations

### DIFF
--- a/config/telink/chip-module/CMakeLists.txt
+++ b/config/telink/chip-module/CMakeLists.txt
@@ -242,11 +242,16 @@ if (CONFIG_BOOTLOADER_MCUBOOT AND (CONFIG_SOC_RISCV_TELINK_B9X OR CONFIG_SOC_RIS
             COMMAND
             cp ${PROJECT_BINARY_DIR}/bootloader_merged.bin ${PROJECT_BINARY_DIR}/mcuboot.bin
         )
-        add_dependencies(merge_sboot build_mcuboot)
         message(WARNING "merged secure boot to mcuboot..")
     else()
-        message(WARNING "File ${SBOOT_FILE_PATH} does not exist. merge_sboot target will not be created.")
+        # Since there is no secure boot, no offset is needed.
+        # Simultaneously check if CONFIG_MCUBOOT_START_OFFSET is 0x0.
+        add_custom_target(merge_sboot ALL
+            cp ${PROJECT_BINARY_DIR}/../modules/chip-module/build_mcuboot/zephyr/zephyr.bin ${PROJECT_BINARY_DIR}/mcuboot.bin
+        )
+        message(WARNING "File ${SBOOT_FILE_PATH} does not exist.")
     endif()
+    add_dependencies(merge_sboot build_mcuboot)
 
     if (EXISTS ${ZB_FILE_PATH})
         add_custom_target(merge_zigbee ALL

--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -306,7 +306,7 @@ public:
     void OnCommissioningSessionEstablishmentStarted() override { sIsCommissioningFailed = false; }
     void OnCommissioningSessionStarted() override { isComissioningStarted = true; }
     void OnCommissioningSessionStopped() override { isComissioningStarted = false; }
-    void OnCommissioningSessionEstablishmentError(CHIP_ERROR err) override { sIsCommissioningFailed = true; }
+    void OnCommissioningSessionEstablishmentError(CHIP_ERROR err) override { sIsCommissioningFailed = true; isComissioningStarted = false; }
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
     void OnCommissioningWindowClosed() override
     {


### PR DESCRIPTION
 - Improve the commissioning flag process and maintain boundary security .
 - Copy a mcuboot.bin from build_mcuboot/.../zephyr.bin in CMakeLists .


